### PR TITLE
feat : 카카오페이 API 를 이용한 포인트 충전기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     //swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
@@ -49,8 +49,11 @@ public class KakaoPayController {
   public ResponseEntity<KakaoPayApproveResponseDto> approvedPointCharge(
       @RequestParam("pg_token") String pgToken,
       @RequestParam("member_id") String memberId, @RequestParam int amount) {
+    // api 요청을 보낸 후 받은 응답
     KakaoPayApproveResponseDto response = kakaoPayApiService
-        .approvedPointCharge(pgToken, memberId, amount);
+        .approvedPointCharge(pgToken, memberId);
+    // api 요청이 정상적으로 끝났다면 DB 에 저장
+    kakaoPayApiService.saveTransactionDataIntoDB(memberId, amount);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
@@ -46,10 +46,11 @@ public class KakaoPayController {
    * @param memberId 거래중인 사용자 ID
    */
   @GetMapping("/success")
-  public ResponseEntity<KakaoPayApproveResponseDto> approvedPointCharge(@RequestParam("pg_token") String pgToken,
-      @RequestParam("member_id") String memberId) {
+  public ResponseEntity<KakaoPayApproveResponseDto> approvedPointCharge(
+      @RequestParam("pg_token") String pgToken,
+      @RequestParam("member_id") String memberId, @RequestParam int amount) {
     KakaoPayApproveResponseDto response = kakaoPayApiService
-        .approvedPointCharge(pgToken, memberId);
+        .approvedPointCharge(pgToken, memberId, amount);
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
@@ -1,0 +1,27 @@
+package com.watchtogether.watchtogether.api.controller;
+
+import com.watchtogether.watchtogether.api.service.KakaoPayApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/kp")
+public class KakaoPayController {
+  private final KakaoPayApiService kakaoPayApiService;
+
+  @GetMapping("/success")
+  public ResponseEntity<?> approvedPointCharge() {
+    // 요청 성공
+
+
+  }
+
+
+
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/controller/KakaoPayController.java
@@ -1,11 +1,17 @@
 package com.watchtogether.watchtogether.api.controller;
 
+import com.watchtogether.watchtogether.api.dto.KakaoPayApproveResponseDto;
+import com.watchtogether.watchtogether.api.dto.KakaoPayResponseDto;
 import com.watchtogether.watchtogether.api.service.KakaoPayApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,15 +19,53 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RequestMapping("/kp")
 public class KakaoPayController {
+
   private final KakaoPayApiService kakaoPayApiService;
 
-  @GetMapping("/success")
-  public ResponseEntity<?> approvedPointCharge() {
-    // 요청 성공
+  /**
+   * 카카오페이 결제를 위한 준비 API 입니다. TID 를 발급받습니다.
+   *
+   * @param amount 결제할 금액
+   * @return Redirect URL , TID 를 포함한 response return
+   */
+  @PostMapping("/prepare")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  public ResponseEntity<?> prepareChargePoint(@RequestParam int amount) {
+    // SecurityContextHolder 에서 인증된 사용자의 ID 를 가져온다.
+    String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+    ResponseEntity<KakaoPayResponseDto> result = kakaoPayApiService
+        .prepareChargePoint(memberId, amount);
 
-
+    return ResponseEntity.ok(result);
   }
 
+  /**
+   * 카카오페이 요청이 성공했을때 실행되는 메서드
+   *
+   * @param pgToken  카카오 서버에서 발급한 pgToken
+   * @param memberId 거래중인 사용자 ID
+   */
+  @GetMapping("/success")
+  public ResponseEntity<KakaoPayApproveResponseDto> approvedPointCharge(@RequestParam("pg_token") String pgToken,
+      @RequestParam("member_id") String memberId) {
+    KakaoPayApproveResponseDto response = kakaoPayApiService
+        .approvedPointCharge(pgToken, memberId);
+    return ResponseEntity.ok(response);
+  }
 
+  /**
+   * 카카오페이 거래가 취소되었을때 실행되는 메서드
+   */
+  @GetMapping("/cancel")
+  public ResponseEntity<String> cancelChargePoint() {
+    return ResponseEntity.ok().body("충전이 취소되었습니다.");
+  }
 
+  /**
+   * 카카오페이 거래가 실패했을때 실행되는 메서드
+   */
+  @GetMapping("/fail")
+  public ResponseEntity<String> failChargePoint() {
+    return ResponseEntity.badRequest().body("충전에 실패했습니다.");
+  }
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveDto.java
@@ -1,0 +1,18 @@
+package com.watchtogether.watchtogether.api.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class KakaoPayApproveDto {
+
+  private String cid;
+  private String tid;
+  private String partner_order_id;
+  private String partner_user_id;
+  private String pg_token;
+
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveDto.java
@@ -1,5 +1,6 @@
 package com.watchtogether.watchtogether.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,8 +12,11 @@ public class KakaoPayApproveDto {
 
   private String cid;
   private String tid;
-  private String partner_order_id;
-  private String partner_user_id;
-  private String pg_token;
+  @JsonProperty("partner_order_id")
+  private String partnerOrderId;
+  @JsonProperty("partner_user_id")
+  private String partnerUserId;
+  @JsonProperty("pg_token")
+  private String pgToken;
 
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveResponseDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveResponseDto.java
@@ -1,0 +1,13 @@
+package com.watchtogether.watchtogether.api.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoPayApproveResponseDto {
+  private String aid; // 요청 고유 번호
+  private String tid; // 결제 고유 번호
+  private LocalDateTime approved_at; // 결제 승인 시간
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveResponseDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayApproveResponseDto.java
@@ -1,5 +1,6 @@
 package com.watchtogether.watchtogether.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.Setter;
 public class KakaoPayApproveResponseDto {
   private String aid; // 요청 고유 번호
   private String tid; // 결제 고유 번호
-  private LocalDateTime approved_at; // 결제 승인 시간
+  @JsonProperty("approved_at")
+  private LocalDateTime approvedAt; // 결제 승인 시간
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
@@ -1,0 +1,42 @@
+package com.watchtogether.watchtogether.api.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class KakaoPayReqeustDto {
+
+  private String cid;
+  private String partner_order_id; // 가맹점 주문번호, 최대 100자
+  private String partner_user_id; // 가맹점 회원 id, 최대 100자
+  // (실명, ID와 같은 개인정보가 포함되지 않도록 유의)
+  private String item_name; // 상품명 최대 100자
+  private int quantity; // 상품 수량
+  private int total_amount; // 상품 총액
+  private int tax_free_amount; // 상품 비과세 금액
+  private String approval_url; // 결제 성공시 url
+  private String cancel_url; // 결제 취소시 url
+  private String fail_url; // 결제 실패시 url
+
+  public static KakaoPayReqeustDto makeRequest(
+      String cid,
+      String orderId,
+      String memberId,
+      int amount) {
+    return KakaoPayReqeustDto.builder()
+        .cid(cid)
+        .partner_order_id(orderId)
+        .partner_user_id(memberId)
+        .item_name("포인트 충전")
+        .quantity(1)
+        .total_amount(amount)
+        .tax_free_amount(0)
+        .approval_url("http://localhost:8080/kp/success")
+        .cancel_url("/")
+        .fail_url("/")
+        .build();
+  }
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
@@ -1,5 +1,6 @@
 package com.watchtogether.watchtogether.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,16 +11,24 @@ import lombok.Setter;
 public class KakaoPayReqeustDto {
 
   private String cid;
-  private String partner_order_id; // 가맹점 주문번호, 최대 100자
-  private String partner_user_id; // 가맹점 회원 id, 최대 100자
+  @JsonProperty("partner_order_id")
+  private String partnerOrderId;// 가맹점 주문번호, 최대 100자
+  @JsonProperty("partner_user_id")
+  private String partnerUserId; // 가맹점 회원 id, 최대 100자
   // (실명, ID와 같은 개인정보가 포함되지 않도록 유의)
-  private String item_name; // 상품명 최대 100자
+  @JsonProperty("item_name")
+  private String itemName; // 상품명 최대 100자
   private int quantity; // 상품 수량
-  private int total_amount; // 상품 총액
-  private int tax_free_amount; // 상품 비과세 금액
-  private String approval_url; // 결제 성공시 url
-  private String cancel_url; // 결제 취소시 url
-  private String fail_url; // 결제 실패시 url
+  @JsonProperty("total_amount")
+  private int totalAmount; // 상품 총액
+  @JsonProperty("tax_free_amount")
+  private int taxFreeAmount; // 상품 비과세 금액
+  @JsonProperty("approval_url")
+  private String approvalUrl; // 결제 성공시 url
+  @JsonProperty("cancel_url")
+  private String cancelUrl; // 결제 취소시 url
+  @JsonProperty("fail_url")
+  private String failUrl; // 결제 실패시 url
 
   public static KakaoPayReqeustDto makeRequest(
       String cid,
@@ -28,16 +37,16 @@ public class KakaoPayReqeustDto {
       int amount) {
     return KakaoPayReqeustDto.builder()
         .cid(cid)
-        .partner_order_id(orderId)
-        .partner_user_id(memberId)
-        .item_name("포인트 충전")
+        .partnerOrderId(orderId)
+        .partnerUserId(memberId)
+        .itemName("포인트 충전")
         .quantity(1)
-        .total_amount(amount)
-        .tax_free_amount(0)
-        .approval_url(
+        .totalAmount(amount)
+        .taxFreeAmount(0)
+        .approvalUrl(
             "http://localhost:8080/kp/success?member_id=" + memberId + "&amount=" + amount)
-        .cancel_url("http://localhost:8080/kp/cancel")
-        .fail_url("http://localhost:8080/kp/fail")
+        .cancelUrl("http://localhost:8080/kp/cancel")
+        .failUrl("http://localhost:8080/kp/fail")
         .build();
   }
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
@@ -34,9 +34,9 @@ public class KakaoPayReqeustDto {
         .quantity(1)
         .total_amount(amount)
         .tax_free_amount(0)
-        .approval_url("http://localhost:8080/kp/success")
-        .cancel_url("/")
-        .fail_url("/")
+        .approval_url("http://localhost:8080/kp/success?member_id=" + memberId)
+        .cancel_url("http://localhost:8080/kp/cancel")
+        .fail_url("http://localhost:8080/kp/fail")
         .build();
   }
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayReqeustDto.java
@@ -34,7 +34,8 @@ public class KakaoPayReqeustDto {
         .quantity(1)
         .total_amount(amount)
         .tax_free_amount(0)
-        .approval_url("http://localhost:8080/kp/success?member_id=" + memberId)
+        .approval_url(
+            "http://localhost:8080/kp/success?member_id=" + memberId + "&amount=" + amount)
         .cancel_url("http://localhost:8080/kp/cancel")
         .fail_url("http://localhost:8080/kp/fail")
         .build();

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayResponseDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayResponseDto.java
@@ -1,0 +1,29 @@
+package com.watchtogether.watchtogether.api.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoPayResponseDto {
+
+  private String tid; // 결제 고유 번호, 20자
+  // 요청한 클라이언트(Client)가 모바일 앱일 경우
+  //카카오톡 결제 페이지 Redirect URL
+  private String next_redirect_app_url;
+  //요청한 클라이언트가 모바일 웹일 경우
+  //카카오톡 결제 페이지 Redirect URL
+  private String next_redirect_mobile_url;
+  //요청한 클라이언트가 PC 웹일 경우
+  //카카오톡으로 결제 요청 메시지(TMS)를 보내기 위한
+  // 사용자 정보 입력 화면 Redirect URL
+  private String next_redirect_pc_url;
+  //카카오페이 결제 화면으로 이동하는 Android 앱 스킴
+  private String android_app_scheme;
+  //카카오페이 결제 화면으로 이동하는 iOS 앱 스킴
+  private String ios_app_scheme;
+  // 결제 준비 요청 시간
+  private LocalDateTime created_at;
+
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayResponseDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayResponseDto.java
@@ -1,11 +1,15 @@
 package com.watchtogether.watchtogether.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoPayResponseDto {
 
   private String tid; // 결제 고유 번호, 20자

--- a/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayResponseDto.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/dto/KakaoPayResponseDto.java
@@ -1,6 +1,7 @@
 package com.watchtogether.watchtogether.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,19 +16,24 @@ public class KakaoPayResponseDto {
   private String tid; // 결제 고유 번호, 20자
   // 요청한 클라이언트(Client)가 모바일 앱일 경우
   //카카오톡 결제 페이지 Redirect URL
-  private String next_redirect_app_url;
+  @JsonProperty("next_redirect_app_url")
+  private String nextRedirectAppUrl;
   //요청한 클라이언트가 모바일 웹일 경우
   //카카오톡 결제 페이지 Redirect URL
-  private String next_redirect_mobile_url;
+  @JsonProperty("next_redirect_mobile_url")
+  private String nextRedirectMobileUrl;
   //요청한 클라이언트가 PC 웹일 경우
   //카카오톡으로 결제 요청 메시지(TMS)를 보내기 위한
   // 사용자 정보 입력 화면 Redirect URL
-  private String next_redirect_pc_url;
+  @JsonProperty("next_redirect_pc_url")
+  private String nextRedirectPCUrl;
   //카카오페이 결제 화면으로 이동하는 Android 앱 스킴
-  private String android_app_scheme;
+  @JsonProperty("android_app_scheme")
+  private String androidAppScheme;
   //카카오페이 결제 화면으로 이동하는 iOS 앱 스킴
-  private String ios_app_scheme;
+  @JsonProperty("ios_app_scheme")
+  private String iosAppScheme;
   // 결제 준비 요청 시간
-  private LocalDateTime created_at;
-
+  @JsonProperty("created_at")
+  private LocalDateTime createdAt;
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/service/KakaoPayApiService.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/service/KakaoPayApiService.java
@@ -1,5 +1,7 @@
 package com.watchtogether.watchtogether.api.service;
 
+import com.watchtogether.watchtogether.api.dto.KakaoPayApproveDto;
+import com.watchtogether.watchtogether.api.dto.KakaoPayApproveResponseDto;
 import com.watchtogether.watchtogether.api.dto.KakaoPayReqeustDto;
 import com.watchtogether.watchtogether.api.dto.KakaoPayResponseDto;
 import java.net.URI;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -21,16 +24,26 @@ public class KakaoPayApiService {
   private final String API_KEY;
   private final String CID_KEY;
   private final String rootUri = "https://open-api.kakaopay.com";
+  private final KakaoPayRedisService kakaoPayRedisService;
 
   // API KEY 를 application.properties 에서 가져온다.
   public KakaoPayApiService(@Value("${kakaoPay.apiKey}") String key,
-      @Value("${kakaoPay.cidKey}") String cidKey, RestTemplateBuilder builder) {
+      @Value("${kakaoPay.cidKey}") String cidKey, RestTemplateBuilder builder,
+      KakaoPayRedisService kakaoPayRedisService) {
     this.API_KEY = key;
     this.CID_KEY = cidKey;
     this.restTemplate = builder.build();
+    this.kakaoPayRedisService = kakaoPayRedisService;
   }
 
-  public ResponseEntity<?> chargePoint(String memberId, int amount) {
+  /**
+   * 카카오페이 결제를 위한 준비단계 메서드.
+   *
+   * @param memberId 사용자의 ID
+   * @param amount   결제할 금액
+   * @return Kakao 서버에서 보내오는 결과값
+   */
+  public ResponseEntity<KakaoPayResponseDto> prepareChargePoint(String memberId, int amount) {
     // 요청보내는 Uri 생성
     URI uri = UriComponentsBuilder.fromUriString(rootUri)
         .path("/online/v1/payment/ready")
@@ -44,11 +57,56 @@ public class KakaoPayApiService {
     KakaoPayReqeustDto request = KakaoPayReqeustDto
         .makeRequest(CID_KEY, "1", memberId, amount);
 
-    HttpEntity<KakaoPayReqeustDto > entity = new HttpEntity<>(request, headers);
+    HttpEntity<KakaoPayReqeustDto> entity = new HttpEntity<>(request, headers);
 
-    ResponseEntity<KakaoPayResponseDto> kakaoPayReqeustDtoResponseEntity = restTemplate.postForEntity(
-        uri, request, KakaoPayResponseDto.class);
+    // 결과를 받아온 response
+    ResponseEntity<KakaoPayResponseDto> response = restTemplate.postForEntity(
+        uri, entity, KakaoPayResponseDto.class);
+
+    // redis 에 응답 정보 임시저장
+    kakaoPayRedisService.saveKakaoPayData(memberId, response.getBody().getTid());
+
+    return response;
   }
 
+  @Transactional
+  public KakaoPayApproveResponseDto approvedPointCharge(String pgToken, String memberId) {
+    // 요청보내는 Uri 생성
+    URI uri = UriComponentsBuilder.fromUriString(rootUri)
+        .path("/online/v1/payment/approve")
+        .encode().build().toUri();
 
+    // Redis 에서 이전 요청에 대한 응답정보 가져오기
+    String tid = kakaoPayRedisService.getKakaoPayData(memberId);
+
+    // TID 와 PgToken 을 담은 새로운 요청 생성
+    KakaoPayApproveDto request = KakaoPayApproveDto.builder()
+        .cid(CID_KEY)
+        .tid(tid)
+        .partner_order_id("1")
+        .partner_user_id(memberId)
+        .pg_token(pgToken)
+        .build();
+
+    // Header 생성
+    HttpHeaders headers = new HttpHeaders();
+    // Header 에 API Key 설정
+    headers.set("Authorization", "SECRET_KEY " + API_KEY);
+
+    // 마지막 요청을 담은 HttpEntity 객체 생성
+    HttpEntity<KakaoPayApproveDto> entity = new HttpEntity<>(request, headers);
+
+    // 최종 승인 응답을 받은 response 객체
+    ResponseEntity<KakaoPayApproveResponseDto> response = restTemplate
+        .postForEntity(uri, entity, KakaoPayApproveResponseDto.class);
+
+    //redis 에서 데이터 삭제
+    kakaoPayRedisService.deleteKakaoPayData(memberId);
+
+    /*
+    TODO : DB에 거래기록 저장하는 기능 구현 必
+     */
+
+    return response.getBody();
+  }
 }

--- a/src/main/java/com/watchtogether/watchtogether/api/service/KakaoPayApiService.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/service/KakaoPayApiService.java
@@ -1,0 +1,54 @@
+package com.watchtogether.watchtogether.api.service;
+
+import com.watchtogether.watchtogether.api.dto.KakaoPayReqeustDto;
+import com.watchtogether.watchtogether.api.dto.KakaoPayResponseDto;
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Slf4j
+public class KakaoPayApiService {
+
+  private final RestTemplate restTemplate;
+  private final String API_KEY;
+  private final String CID_KEY;
+  private final String rootUri = "https://open-api.kakaopay.com";
+
+  // API KEY 를 application.properties 에서 가져온다.
+  public KakaoPayApiService(@Value("${kakaoPay.apiKey}") String key,
+      @Value("${kakaoPay.cidKey}") String cidKey, RestTemplateBuilder builder) {
+    this.API_KEY = key;
+    this.CID_KEY = cidKey;
+    this.restTemplate = builder.build();
+  }
+
+  public ResponseEntity<?> chargePoint(String memberId, int amount) {
+    // 요청보내는 Uri 생성
+    URI uri = UriComponentsBuilder.fromUriString(rootUri)
+        .path("/online/v1/payment/ready")
+        .encode().build().toUri();
+
+    // Header 생성
+    HttpHeaders headers = new HttpHeaders();
+    // Header 에 API Key 설정
+    headers.set("Authorization", "SECRET_KEY " + API_KEY);
+    // Body 생성
+    KakaoPayReqeustDto request = KakaoPayReqeustDto
+        .makeRequest(CID_KEY, "1", memberId, amount);
+
+    HttpEntity<KakaoPayReqeustDto > entity = new HttpEntity<>(request, headers);
+
+    ResponseEntity<KakaoPayResponseDto> kakaoPayReqeustDtoResponseEntity = restTemplate.postForEntity(
+        uri, request, KakaoPayResponseDto.class);
+  }
+
+
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/service/KakaoPayRedisService.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/service/KakaoPayRedisService.java
@@ -1,0 +1,32 @@
+package com.watchtogether.watchtogether.api.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoPayRedisService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  // 데이터 저장하기
+  public void saveKakaoPayData(String memberId, String tid) {
+    String key = "kakao: " + memberId;
+    // 1분간 redis 에 저장
+    redisTemplate.opsForValue().set(key, tid, 1, TimeUnit.MINUTES);
+  }
+
+  // 데이터 가져오기
+  public String getKakaoPayData(String memberId) {
+    String key = "kakao: " + memberId;
+    return redisTemplate.opsForValue().get(key);
+  }
+
+  // 데이터 삭제
+  public void deleteKakaoPayData(String memberId) {
+    String key = "kakao: " + memberId;
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/watchtogether/watchtogether/api/service/TmdbApiService.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/service/TmdbApiService.java
@@ -1,4 +1,4 @@
-package com.watchtogether.watchtogether.api;
+package com.watchtogether.watchtogether.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -49,7 +49,9 @@ public class TmdbApiService {
         .queryParam("language", "ko-KR")
         .encode().build().toUri();
 
+    // Header 생성
     HttpHeaders headers = new HttpHeaders();
+    // Header 에 API Key 설정
     headers.set("Authorization", "Bearer " + API_KEY);
     HttpEntity<String> entity = new HttpEntity<>(headers);
 

--- a/src/main/java/com/watchtogether/watchtogether/api/service/TmdbApiService.java
+++ b/src/main/java/com/watchtogether/watchtogether/api/service/TmdbApiService.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.watchtogether.watchtogether.exception.custom.MovieDataNotFoundException;
 import com.watchtogether.watchtogether.movie.entity.Movie;
 import java.net.URI;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -20,18 +20,14 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class TmdbApiService {
 
-  private final String API_KEY;
+  @Value("${tmdb.apiKey}")
+  private String API_KEY;
   private final String rootUri = "https://api.themoviedb.org/3";
   private final String posterBaseUri = "https://image.tmdb.org/t/p/original";
   private final RestTemplate restTemplate;
-
-  // API KEY 를 application.properties 에서 가져온다.
-  public TmdbApiService(@Value("${tmdb.apiKey}") String key, RestTemplateBuilder builder) {
-    this.API_KEY = key;
-    this.restTemplate = builder.build();
-  }
 
   /**
    * 영화 제목으로 영화 목록 가져오기
@@ -39,12 +35,12 @@ public class TmdbApiService {
    * @param title 영화제목
    * @return 영화들의 List 리턴
    */
-  public ResponseEntity<String> getMovieList(int page,String title) {
+  public ResponseEntity<String> getMovieList(int page, String title) {
     // API 요청을 위한 URI 생성
     URI uri = UriComponentsBuilder.fromUriString(rootUri)
         .path("/search/movie")
         .queryParam("query", title)
-        .queryParam("page",page)
+        .queryParam("page", page)
         .queryParam("include_adult", "true")
         .queryParam("language", "ko-KR")
         .encode().build().toUri();

--- a/src/main/java/com/watchtogether/watchtogether/config/RestTemplateConfig.java
+++ b/src/main/java/com/watchtogether/watchtogether/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.watchtogether.watchtogether.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/watchtogether/watchtogether/config/SecurityConfig.java
+++ b/src/main/java/com/watchtogether/watchtogether/config/SecurityConfig.java
@@ -48,11 +48,11 @@ public class SecurityConfig {
     http
         .authorizeHttpRequests((request) ->
             request.requestMatchers(
-                    "/","/swagger-ui/**", "/v3/api-docs/**","/v3/api-docs").permitAll()
+                    "/", "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs").permitAll()
                 .requestMatchers(
                     "/member/join", "/movie/list/screen", "/movie/detail/**",
-                    "/member/join", "/member/login", "/cinema/info","/movie/list").permitAll()
-
+                    "/member/join", "/member/login", "/cinema/info", "/movie/list").permitAll()
+                .requestMatchers("/kp/fail", "/kp/success", "/kp/cancel").permitAll()
                 .anyRequest().authenticated());
 
     // JWT 필터 추가

--- a/src/main/java/com/watchtogether/watchtogether/config/SecurityConfig.java
+++ b/src/main/java/com/watchtogether/watchtogether/config/SecurityConfig.java
@@ -52,9 +52,8 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/member/join", "/movie/list/screen", "/movie/detail/**",
                     "/member/join", "/member/login", "/cinema/info", "/movie/list").permitAll()
-                .requestMatchers("/kp/fail", "/kp/success", "/kp/cancel").permitAll()
-                    "/member/join", "/member/login", "/cinema/info", "/movie/list"
-                    , "/member/info").permitAll()
+                .requestMatchers("/kp/fail", "/kp/success", "/kp/cancel", "/member/info")
+                .permitAll()
 
                 .anyRequest().authenticated());
 

--- a/src/main/java/com/watchtogether/watchtogether/history/point/service/TransactionHistoryService.java
+++ b/src/main/java/com/watchtogether/watchtogether/history/point/service/TransactionHistoryService.java
@@ -8,6 +8,7 @@ import com.watchtogether.watchtogether.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -18,13 +19,13 @@ public class TransactionHistoryService {
   private final MemberRepository memberRepository;
 
   /**
-   * 포인트 사용하는 메서드 이 메서드를 호출함으로써 포인트 차감 / 증가가 된다. 트랜잭션은 이 메서드를 호출하는 쪽 한곳에서만 적용한다. 호출한 쪽 메서드에서 예외가
-   * 발생하면 usePoint() 메서드도 롤백된다.
+   * 포인트 사용하는 메서드 이 메서드를 호출함으로써 포인트 차감 / 증가가 된다.
    *
    * @param member 사용하려는 Member
    * @param amount 사용하려는 포인트 양 (양수는 충전 , 음수는 사용)
    * @param detail 사용하는 사용처
    */
+  @Transactional
   public void usePoint(Member member, int amount, TransactionDetail detail) {
     // 거래정보를 담은 history 데이터 생성
     PointTransactionHistory history = PointTransactionHistory.builder()

--- a/src/main/java/com/watchtogether/watchtogether/meeting/service/MeetingService.java
+++ b/src/main/java/com/watchtogether/watchtogether/meeting/service/MeetingService.java
@@ -1,6 +1,6 @@
 package com.watchtogether.watchtogether.meeting.service;
 
-import com.watchtogether.watchtogether.api.TmdbApiService;
+import com.watchtogether.watchtogether.api.service.TmdbApiService;
 import com.watchtogether.watchtogether.cinema.entity.Cinema;
 import com.watchtogether.watchtogether.cinema.repository.CinemaRepository;
 import com.watchtogether.watchtogether.exception.custom.CinemaNotFoundException;
@@ -87,7 +87,7 @@ public class MeetingService {
         .build();
     WatchMeeting savedMeeting = meetingRepository.save(watchMeeting);
     // 같이볼까요 신청기록 저장
-    meetingHistoryService.recordMeetingHistory(member,savedMeeting);
+    meetingHistoryService.recordMeetingHistory(member, savedMeeting);
 
     return watchMeeting;
   }

--- a/src/main/java/com/watchtogether/watchtogether/movie/service/MovieService.java
+++ b/src/main/java/com/watchtogether/watchtogether/movie/service/MovieService.java
@@ -1,6 +1,6 @@
 package com.watchtogether.watchtogether.movie.service;
 
-import com.watchtogether.watchtogether.api.TmdbApiService;
+import com.watchtogether.watchtogether.api.service.TmdbApiService;
 import com.watchtogether.watchtogether.movie.dto.MovieIdNameDateDto;
 import com.watchtogether.watchtogether.movie.dto.MovieListPageDto;
 import com.watchtogether.watchtogether.movie.entity.Movie;


### PR DESCRIPTION
**TO-BE**
카카오페이 API 를 이용한 포인트 충전기능 구현 완료했습니다.

충전이 성공하면 내부DB에 거래기록이 저장됩니다.

KakaoPayController -> prepareChargePoint() 메서드가 호출된 뒤 사용자 인증되면 approvedPointCharge() 메서드로 redirect 됨.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 